### PR TITLE
chore: replace Harbor registry endpoint

### DIFF
--- a/.github/workflows/build_push_harbor.yaml
+++ b/.github/workflows/build_push_harbor.yaml
@@ -13,7 +13,7 @@ permissions:
 
 env:
   APP: lido-circ-supply
-  REGISTRY: harbor.dev.k8s-dev.org
+  REGISTRY: registry.dev.k8s-dev.org
   REPOSITORY: team-daotech
   REGISTRY_USER: robot$team-daotech-rw
   IMAGE_TAG: dev


### PR DESCRIPTION
Replaces harbor.dev.k8s-dev.org with registry.dev.k8s-dev.org. Do not merge till endpoints are actually switched in k8s-cluster!